### PR TITLE
Links and scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,15 +26,28 @@ The Secure Assets extension also includes support for other [authentication sche
 
 The fields in the table below can be used in these parts of STAC documents:
 
-- [ ] Catalogs
+- [x] Catalogs
 - [x] Collections
 - [x] Item Properties (incl. Summaries in Collections)
-- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
+- [ ] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
 - [ ] Links
 
 | Field Name | Type                                                    | Description                                            |
 | ---------- | ------------------------------------------------------- | ------------------------------------------------------ |
 | security:schemes | Map<string, [SecureAssetSchemeObject](#secure-asset-scheme-object)> | A property that contains all of the [scheme definitions](#secure-asset-scheme-object) used by Assets in the STAC Item or Collection. |
+
+---
+
+The fields in the table below can be used in these parts of STAC documents:
+
+- [ ] Catalogs
+- [ ] Collections
+- [ ] Item Properties (incl. Summaries in Collections)
+- [x] Assets (for both Collections and Items, incl. Item Asset Definitions in Collections)
+- [x] Links
+
+| Field Name | Type                                                    | Description                                            |
+| ---------- | ------------------------------------------------------- | ------------------------------------------------------ |
 | security:refs | \[string\] | An Asset property that specifies which schemes in `security:schemes` may be used to access an Asset. |
 
 ### Scheme Types


### PR DESCRIPTION
Do you think it would make sense to allow security refs also for links?

It may also make sense to split the table and clearly show that the fields can be used in different scopes.

Still a draft as this would incur schema changes, but I wanted to show the anticipated changes first for feedback.
