### PR TITLE
parameters object and method field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added parameters object
+- Support to describe signed URL request method and parmeters.
+
 - Links examples in README.md
 
 - `security:refs` parameter to Link objects in Items or Collections.
 
-- Added `security:schemas` Item and Collection property which defines all the security schemas.
+- Added `security:schemes` Item and Collection property which defines all the security schemas.
 - Added Asset parameter `security:refs` which specifies which schemes from `security:schemes` can be used for an asset.
 
 - Initial commit of README.md

--- a/README.md
+++ b/README.md
@@ -89,14 +89,26 @@ the supported OAuth Flows.
 
 Configuration details for a supported OAuth Flow
 
-#### Fixed Fields
 | Field Name | Type | Description |
 | ---|:---:|--- |
 | `authorizationUrl` | `string` | Required for `oauth2` (`"implicit"`, `"authorizationCode"`). The authorization URL to be used for this flow. This MUST be in the form of a URL.  |
 | `tokenUrl` | `string` | Required for `oauth2` (`"password"`, `"clientCredentials"`, `"authorizationCode"`). The token URL to be used for this flow. This MUST be in the form of a URL.  |
 | `authorizationApi` | `string` | Optional for `signedUrl`. The signed URL API endpoint to be used for this flow. If not enferred from the client environment, this must be defined in the authentication flow.  |
 | `refreshUrl` | `string` | Optional for `oauth2`. The URL to be used for obtaining refresh tokens. This MUST be in the form of a URL.  |
-| `scopes` | Map\[`string`, `string`\] | Required for `oauth2`. The available scopes for the authentication scheme. A map between the scope name and a short description for it. The map MAY be empty. |
+| `scopes` | Map<`string`, `string`> | Required for `oauth2`. The available scopes for the authentication scheme. A map between the scope name and a short description for it. The map MAY be empty. |
+| `method` | `string` | Required for `signedUrl`. The method to be used for requests |
+| `parameters` | Map<string, [ParameterObject](#parameter-object)> | Optional for `signedUrl`. Parameter definition for requests to the `authorizationApi` |
+
+### Parameter Object
+
+Definition for a request parameter
+
+| Field Name | Type | Description |
+| ---|:---:|--- |
+| `in` | `string` | The location of the parameter (`query` | `header` | `body`). |
+| `required` | `boolean` | Setting for optional or required parameter |
+| `description` | `string` | Optional. Plain language description of the parameter |
+| `schema` | `object` | Optional. Schema object following the [OpenAPI extended subset](https://swagger.io/docs/specification/data-models/) of the [JSON Schema spec](https://json-schema.org/) |
 
 ### Examples
 
@@ -165,8 +177,27 @@ authentication scheme can be defined with
       "type": "signedUrl",
       "description": "Requires an authentication API",
       "flows": {
-        "signedUrl": {
-            "authorizationApi": "https://example.com/signed_url/authorize"
+        "authorizationApi": "https://example.com/signed_url/authorize",
+        "method": "POST",
+        "parameters": {
+          "bucket": {
+            "in": "body",
+            "required": true,
+            "description": "asset bucket",
+            "schema": {
+              "type": "string",
+              "examples": "example-bucket"
+            }
+          },
+          "key": {
+            "in": "body",
+            "required": true,
+            "description": "asset key",
+            "schema": {
+              "type": "string",
+              "examples": "path/to/example/asset.xyz"
+            }
+          }
         }
       }
     }

--- a/examples/collection.json
+++ b/examples/collection.json
@@ -47,8 +47,27 @@
       "type": "signedUrl",
       "description": "Requires an authentication API",
       "flows": {
-        "signedUrl": {
-          "authorizationApi": "https://example.com/signed_url/authorize"
+        "authorizationApi": "https://example.com/signed_url/authorize",
+        "method": "POST",
+        "parameters": {
+          "bucket": {
+            "in": "body",
+            "required": true,
+            "description": "asset-bucket",
+            "schema": {
+              "type": "string",
+              "examples": "example-bucket"
+            }
+          },
+          "key": {
+            "in": "body",
+            "required": true,
+            "description": "asset key",
+            "schema": {
+              "type": "string",
+              "examples": "path/to/example/asset.xyz"
+            }
+          }
         }
       }
     }

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -274,6 +274,10 @@
                 "bearer"
               ]
             },
+            "openConnectUrl": {
+              "title": "This URL returns a JSON listing of the OpenID/OAuth endpoints, supported scopes and claims, public keys used to sign the tokens, and other details",
+              "type": "string"
+            },
             "flows": {
               "title": "Scenarios an API client performs to get an access token from the authorization server",
               "type": "object",
@@ -297,19 +301,43 @@
                 "scopes": {
                   "title": "The available scopes for the authentication scheme",
                   "type": "object"
+                },
+                "method": {
+                  "title": "HTTP request method",
+                  "type": "string",
+                  "examples": [
+                    "POST",
+                    "GET"
+                  ]
+                },
+                "parameters": {
+                  "title": "Parameter definitions for requests to the authorizationApi",
+                  "type": "object",
+                  "properties": {
+                    "in": {
+                      "title": "Location of the parameter",
+                      "type": "string",
+                      "examples": [
+                        "query",
+                        "header",
+                        "body"
+                      ]
+                    },
+                    "required": {
+                      "title": "Setting for optional or required parameter",
+                      "type": "boolean"
+                    },
+                    "description": {
+                      "title": "Plain language description of the parameter",
+                      "type": "string"
+                    },
+                    "scopes": {
+                      "title": "Schema object following the OpenAPI extended subset of the JSON Schema spec",
+                      "type": "object"
+                    }
+                  }
                 }
-              },
-              "examples": [
-                "authorizationCode",
-                "implicit",
-                "password",
-                "clientCredentials",
-                "signedUrl"
-              ]
-            },
-            "openConnectUrl": {
-              "title": "This URL returns a JSON listing of the OpenID/OAuth endpoints, supported scopes and claims, public keys used to sign the tokens, and other details",
-              "type": "object"
+              }
             }
           }
         }


### PR DESCRIPTION
This PR adds the ability to specify the method and parameters required for a request to a signed URL authorization API. Parameter definitions are based on the OpenAPI spec (https://swagger.io/docs/specification/describing-parameters/)

