### PR TITLE
Add uri-js dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Add uri-js ^4.4.1 as a dependency [#35](https://github.com/stac-extensions/authentication/pull/35)
+
 ## [v1.1.0] - 2023-04-28
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "stac-extensions",
+  "name": "stac-extension-authentication",
   "version": "1.1.0",
   "scripts": {
     "test": "npm run check-markdown && npm run check-examples",
@@ -15,6 +15,7 @@
     "remark-preset-lint-markdown-style-guide": "^3.0.0",
     "remark-preset-lint-recommended": "^4.0.0",
     "remark-validate-links": "^10.0.0",
-    "stac-node-validator": "^1.0.0"
+    "stac-node-validator": "^1.3.0",
+    "uri-js": "^4.4.1"
   }
 }


### PR DESCRIPTION
The stac-node-validator step in the test had started to fail with the error:
```bash
> stac-extension-authentication@1.1.0 check-examples
> stac-node-validator . --lint --verbose --schemaMap https://stac-extensions.github.io/authentication/v1.1.0/schema.json=./json-schema/schema.json

node:internal/modules/cjs/loader:1042
  throw err;
  ^

Error: Cannot find module 'uri-js'
Require stack:
- /mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/iri.js
- /mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/index.js
- /mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/bin/cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1039:15)
    at Module._load (node:internal/modules/cjs/loader:885:27)
    at Module.require (node:internal/modules/cjs/loader:1105:19)
    at require (node:internal/modules/cjs/helpers:103:18)
    at Object.<anonymous> (/mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/iri.js:1:19)
    at Module._compile (node:internal/modules/cjs/loader:1218:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1272:10)
    at Module.load (node:internal/modules/cjs/loader:1081:32)
    at Module._load (node:internal/modules/cjs/loader:922:12)
    at Module.require (node:internal/modules/cjs/loader:1105:19) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/iri.js',
    '/mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/index.js',
    '/mnt/c/Users/james/Documents/github/authentication/node_modules/stac-node-validator/bin/cli.js'
  ]
}

Node.js v18.13.0
```

Adding uri-js as a dependency resolves the issue. I am not sure what introduced this bug. 